### PR TITLE
fix: elixir warning

### DIFF
--- a/lib/holidefs.ex
+++ b/lib/holidefs.ex
@@ -51,7 +51,7 @@ defmodule Holidefs do
     za: "South Africa"
   }
 
-  @locale_keys Application.get_env(:holidefs, :locales, Map.keys(@all_locales))
+  @locale_keys Application.compile_env(:holidefs, :locales, Map.keys(@all_locales))
   @locales Map.take(@all_locales, @locale_keys)
 
   @doc """


### PR DESCRIPTION
Fixes the following:

```
warning: Application.get_env/3 is discouraged in the module body, use Application.compile_env/3 instead
```