### PR TITLE
fix dependency on :crypto app

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule Holidefs.Mixfile do
 
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger, :crypto]
     ]
   end
 


### PR DESCRIPTION
The private `Holidefs.Holiday.generate_uid/3` function uses `:crypto.hash/2`.

The `:crypto` module is part of an application of the same name.  Since a dependency is not specified, it's possible for the app to not be started yet when that function is called.

This PR declares the dependency explicitly in `mix.exs`.