### PR TITLE
fix typespec for Holidefs.Definition.Rule

### DIFF
--- a/lib/holidefs/definition/rule.ex
+++ b/lib/holidefs/definition/rule.ex
@@ -27,10 +27,10 @@ defmodule Holidefs.Definition.Rule do
           day: integer,
           week: integer,
           weekday: integer,
-          function: function,
-          function_modifier: integer,
+          function: atom | nil,
+          function_modifier: integer | nil,
           regions: [String.t()],
-          observed: function,
+          observed: atom | nil,
           year_ranges: map | nil,
           informal?: boolean
         }


### PR DESCRIPTION
`observed` and `function` keys specified as being of `function` type.  Code pretty clearly returns an atom or `nil`.  Also added `nil` to type for `function_modifier`, as it's optional.

This was causing a whole bunch of Dialyzer failures which were leaking out to my code downstream.

This is a reformulated branch for the fix in PR #42.  The original PR unfortunately leaked some unrelated changes in.  This new, clean branch should be correct.  I'll close the old one.